### PR TITLE
Proposal for mandatory use of framework functions

### DIFF
--- a/es6.md
+++ b/es6.md
@@ -945,6 +945,16 @@ const a = {
 
 *Pure convention. Also, `Promise` and `yield` are interoperable, see [`Promise#coroutine`](https://github.com/petkaantonov/bluebird/blob/master/API.md#generators).*
 
-## JSX/React
+## Prefer lodash before own implementation where applicable
+- Any functionality that is present in lodash (or any other framework) **must** be used instead of own implementations.
+```
+// bad
+if(['foo', 'bar'].indexof('foo') !== -1){
+...
+}
 
-TBD.
+// good
+if(_.contains(['foo', 'bar'], 'foo'){
+...
+}
+```

--- a/es6.md
+++ b/es6.md
@@ -377,6 +377,11 @@ if(expr) {
   ...
 }
 
+// better: explicit type conversion
+if(Boolean(expr)) {
+  ...
+}
+
 // acceptable to prevent leaking values
 someUntrustedFunction(!!expr);
 ```

--- a/es6.md
+++ b/es6.md
@@ -364,7 +364,7 @@ n = n + 1;
 
 - Non-strict comparison operators `==` or `!=` **must not** be used. Strict comparison operators `===` or `!==` **must** be used instead.
 
-- Boolean force-casting `!!expr` **should not** be used. `expr` **should** BE used directly, unless you specifically care about leaking values in a function call or a return value.
+- Boolean force-casting `!!expr` **should not** be used. `expr` **should** BE used directly or explictly converted into the expected type, unless you specifically care about leaking values in a function call or a return value.
 
 ```js
 // bad

--- a/es6.md
+++ b/es6.md
@@ -242,6 +242,16 @@ const triple = x => 3*x;
 const triple = (x) => 3*x;
 ```
 
+- The arrow symbol **must** be separated from the parameters and function body with a leading and trailing whitespace.
+
+```js
+// bad
+const triple = (x)=>3*x;
+
+// good
+const triple = (x) => 3*x;
+```
+
 - Arrow functions **should** be used instead of `Function.prototype.bind` when applicable. `self` / `_this` / `that` trickery **must not** be used.
 
 ```js


### PR DESCRIPTION
Proposal for mandatory use of framework functions
I think it would be preferable to force the use of framework functions where available.

One addition I'm unsure about is wether to prefer framework functions also over native functions like 

```
// bad
['foo', 'bar'].foreach((x) => {log(x)})

// good
_.foreach(['foo', 'bar']), (x) => {log(x)})

//maybe even better???
//wrapping values makes calls very similar but enables chaining
_(['foo', 'bar']).foreach((x) => {log(x)}).run()

```
