### PR TITLE
Foreign key's name reduced

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ This repository contains my coding style guidelines.
 - [PostgreSQL coding guidelines](postgres.md)
 
 An [`.eslintrc`](.eslintrc) file with pre-configured rules is available if you wish to use [ESLint](http://eslint.org/).
+It currently works under `1.10.1` version.

--- a/postgres.md
+++ b/postgres.md
@@ -208,34 +208,28 @@ CREATE TABLE foo(bar integer, NOT NULL (bar));
 CREATE TABLE foo(bar integer NOT NULL);
 ```
 
-##### `PRIMARY KEY` constraints must be declared into the table declaration WITH explicit column reference.
+##### As they are unique, `PRIMARY KEY` constraints must be named based on the `pkey_*table*` pattern.
 ```sql
 -- bad
-CREATE TABLE foo(foo_id serial PRIMARY KEY);
+ALTER TABLE foo ADD CONSTRAINT foo_foo_id_pkey PRIMARY KEY (foo_id);
 
 -- good
-CREATE TABLE foo(foo_id serial, PRIMARY KEY (foo_id));
+ALTER TABLE foo ADD CONSTRAINT pkey_foo PRIMARY KEY (foo_id);
 ```
 
-##### Other constraints must be explicitly named based on the `*key*_*table*_on_*column*(_and_*column*)` pattern (keys are: `fkey` for `FOREIGN KEY`, `key` for `UNIQUE`, `check` for `CHECK`).
+##### Other constraints must be explicitly named based on the `*key*_*table*_on_*column*(_and_*column*)` pattern.
+Keys are: `fkey` for `FOREIGN KEY`, `key` for `UNIQUE`, `check` for `CHECK`.
 ```sql
--- bad
-CREATE TABLE foo(bar_id integer REFERENCES bar(bar_id));
-
--- good
-CREATE TABLE foo(bar_id integer, CONSTRAINT fkey_foo_on_bar_id FOREIGN KEY bar_id REFERENCES bar(bar_id));
+CREATE TABLE foo(foo_id serial, bar_id integer);
 
 -- bad
-CREATE TABLE foo(bar text UNIQUE);
+ALTER TABLE foo ADD CONSTRAINT foo_bar_id_fkey FOREIGN KEY bar_id REFERENCES bar(bar_id);
 
 -- good
-CREATE TABLE foo(bar text, CONSTRAINT key_foo_on_bar UNIQUE (bar));
-
--- bad
-CREATE TABLE foo(bar integer CHECK (bar > 1));
+ALTER TABLE foo ADD CONSTRAINT fkey_foo_on_bar_id FOREIGN KEY bar_id REFERENCES bar(bar_id);
 
 -- good
-CREATE TABLE foo(bar integer, CONSTRAINT check_foo_on_bar CHECK (bar > 1));
+ALTER TABLE foo ADD CONSTRAINT check_foo_on_foo_id_and_bar_id CHECK (foo_id > bar_id);
 ```
 
 ## Indexes ##


### PR DESCRIPTION
Foreign key does not have to use its column name anymore as it is always a unique constraint name.

Add to global doc the ESLint version used to define `.eslintrc` rules.
